### PR TITLE
fixed gesture detector area, added feedback on hover

### DIFF
--- a/lib/presentation/widgets/tool_card.dart
+++ b/lib/presentation/widgets/tool_card.dart
@@ -2,44 +2,73 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:devtoys/domain/models/tools/tool.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:yaru_colors/yaru_colors.dart';
 
-class ToolCard extends StatelessWidget {
+class ToolCard extends StatefulWidget {
   final Tool tool;
 
   ToolCard(this.tool);
 
   @override
+  State<ToolCard> createState() => _ToolCardState();
+}
+
+class _ToolCardState extends State<ToolCard> {
+  Color cardColor = Colors.transparent;
+
+  void onHoverIn(PointerEvent _) {
+    setState(() {
+      cardColor = Color.fromARGB(99, 132, 132, 132);
+      // cardColor = YaruColors.coolGrey; not using this as its the same as the background color.
+    });
+  }
+
+  void onHoverOut(PointerEvent _) {
+    setState(() {
+      cardColor = Colors.transparent;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => Get.toNamed(tool.route),
-      child: Container(
-        margin: EdgeInsets.only(right: 50, left: 50, top: 15, bottom: 15),
-        decoration: BoxDecoration(
-          borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-        ),
-        child: Card(
-          surfaceTintColor: Colors.transparent,
-          // color: Color.fromRGBO(53, 53, 53, 1),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Icon(tool.icon, size: 75),
-              SizedBox(height: 10),
-              AutoSizeText(
-                tool.name,
-                style: TextStyle(fontSize: 21, fontWeight: FontWeight.bold),
-                textAlign: TextAlign.center,
-              ),
-              SizedBox(height: 10),
-              Flexible(
-                child: AutoSizeText(tool.description,
-                    style:
-                        TextStyle(fontSize: 17, fontWeight: FontWeight.normal),
+    return Padding(
+      padding: EdgeInsets.only(right: 50, left: 50, top: 15, bottom: 15),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: onHoverIn,
+        onExit: onHoverOut,
+        child: GestureDetector(
+          onTap: () => Get.toNamed(widget.tool.route),
+          child: Container(
+            // margin: EdgeInsets.only(right: 50, left: 50, top: 15, bottom: 15),
+            decoration: BoxDecoration(
+              borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+            ),
+            child: Card(
+              surfaceTintColor: cardColor,
+              // color: Color.fromRGBO(53, 53, 53, 1),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Icon(widget.tool.icon, size: 75),
+                  SizedBox(height: 10),
+                  AutoSizeText(
+                    widget.tool.name,
+                    style: TextStyle(fontSize: 21, fontWeight: FontWeight.bold),
                     textAlign: TextAlign.center,
-                    overflow: TextOverflow.fade),
+                  ),
+                  SizedBox(height: 10),
+                  Flexible(
+                    child: AutoSizeText(widget.tool.description,
+                        style: TextStyle(
+                            fontSize: 17, fontWeight: FontWeight.normal),
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.fade),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -290,7 +290,7 @@ packages:
     source: hosted
     version: "0.1.0"
   yaru_colors:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaru_colors
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   font_awesome_flutter: ^10.2.1
   code_text_field: ^1.0.2
   resizable_widget: ^1.0.5
+  yaru_colors: ^0.1.0
 
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
Hi!

I noticed that the margin for the container is inside GestureDetector, which causes teh button to activate even when pressed outside the button area. Changed it by removing the margin  and adding padding around the gesture detector.

I added MouseRegion for the card so the mouse cursor changes to link select icon when hovering on a button. Also added color fade to the button for better visual feedback. Had to change the widget to stateful though, for active color change.

I am new to Get, is there a way to do the color change in Get without converting the toolcard widget to stateful ?

Preview:

https://user-images.githubusercontent.com/60005847/192576399-f45797ea-06dc-4b8a-a755-51d409668854.mp4


